### PR TITLE
Set default for nat_key_name var

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,6 @@
 variable "aws_access_key" {}
 variable "aws_secret_key" {}
 variable "aws_region" {}
-variable "nat_key_name" {}
 
 variable "org_name" {}
 
@@ -122,4 +121,8 @@ variable "nat_gateway_enabled" {
 
 variable "nat_instance_type" {
     default = "t2.micro"
+}
+
+variable "nat_key_name" {
+    default = ""
 }


### PR DESCRIPTION
This variable is only required for NAT instances. Set empty default to allow it
to be unset for NAT gateways usage.

Fixes #5
