### PR TITLE
route-table: Move route out of table resource

### DIFF
--- a/route-table.tf
+++ b/route-table.tf
@@ -1,16 +1,19 @@
 # Routing table for public subnets
 resource "aws_route_table" "public" {
   vpc_id = "${aws_vpc.default.id}"
-    route {
-      cidr_block = "0.0.0.0/0"
-      gateway_id = "${aws_internet_gateway.default.id}"
-    }
   tags = "${merge(var.global_tags, map("Name", "public"))}"
 }
 
 output "aws_route_table_public_ids" {
   value = ["${aws_route_table.public.id}"]
 }
+
+resource "aws_route" "public_internet_gateway" {
+  route_table_id = "${aws_route_table.public.id}"
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id = "${aws_internet_gateway.default.id}"
+}
+
 
 # Routing table for private subnets
 resource "aws_route_table" "private" {

--- a/tests/fixtures/terraform.1az.tfvars.example.output
+++ b/tests/fixtures/terraform.1az.tfvars.example.output
@@ -48,6 +48,18 @@ Note: You didn't specify an "-out" parameter to save this plan, so when
     route_table_id:             "<computed>"
     state:                      "<computed>"
 [0m
+[0m[32m+ aws_route.public_internet_gateway
+[0m    destination_cidr_block:     "0.0.0.0/0"
+    destination_prefix_list_id: "<computed>"
+    gateway_id:                 "<computed>"
+    instance_id:                "<computed>"
+    instance_owner_id:          "<computed>"
+    nat_gateway_id:             "<computed>"
+    network_interface_id:       "<computed>"
+    origin:                     "<computed>"
+    route_table_id:             "<computed>"
+    state:                      "<computed>"
+[0m
 [0m[32m+ aws_route_table.private
 [0m    route.#:         "<computed>"
     tags.%:          "3"
@@ -57,18 +69,12 @@ Note: You didn't specify an "-out" parameter to save this plan, so when
     vpc_id:          "<computed>"
 [0m
 [0m[32m+ aws_route_table.public
-[0m    route.#:                                     "1"
-    route.~1259162026.cidr_block:                "0.0.0.0/0"
-    route.~1259162026.gateway_id:                "<computed>"
-    route.~1259162026.instance_id:               ""
-    route.~1259162026.nat_gateway_id:            ""
-    route.~1259162026.network_interface_id:      ""
-    route.~1259162026.vpc_peering_connection_id: ""
-    tags.%:                                      "3"
-    tags.Author:                                 "ReactiveOps"
-    tags.Managed By:                             "Terraform"
-    tags.Name:                                   "public"
-    vpc_id:                                      "<computed>"
+[0m    route.#:         "<computed>"
+    tags.%:          "3"
+    tags.Author:     "ReactiveOps"
+    tags.Managed By: "Terraform"
+    tags.Name:       "public"
+    vpc_id:          "<computed>"
 [0m
 [0m[32m+ aws_route_table_association.private_admin
 [0m    route_table_id: "<computed>"
@@ -143,4 +149,4 @@ Note: You didn't specify an "-out" parameter to save this plan, so when
     tags.Name:                 "vpc-module-test"
 [0m
 [0m
-[0m[1mPlan:[0m 15 to add, 0 to change, 0 to destroy.[0m
+[0m[1mPlan:[0m 16 to add, 0 to change, 0 to destroy.[0m

--- a/tests/fixtures/terraform.nat-gw.tfvars.example.output
+++ b/tests/fixtures/terraform.nat-gw.tfvars.example.output
@@ -106,6 +106,18 @@ Note: You didn't specify an "-out" parameter to save this plan, so when
     route_table_id:             "<computed>"
     state:                      "<computed>"
 [0m
+[0m[32m+ aws_route.public_internet_gateway
+[0m    destination_cidr_block:     "0.0.0.0/0"
+    destination_prefix_list_id: "<computed>"
+    gateway_id:                 "<computed>"
+    instance_id:                "<computed>"
+    instance_owner_id:          "<computed>"
+    nat_gateway_id:             "<computed>"
+    network_interface_id:       "<computed>"
+    origin:                     "<computed>"
+    route_table_id:             "<computed>"
+    state:                      "<computed>"
+[0m
 [0m[32m+ aws_route_table.private.0
 [0m    route.#:         "<computed>"
     tags.%:          "3"
@@ -131,18 +143,12 @@ Note: You didn't specify an "-out" parameter to save this plan, so when
     vpc_id:          "<computed>"
 [0m
 [0m[32m+ aws_route_table.public
-[0m    route.#:                                     "1"
-    route.~1259162026.cidr_block:                "0.0.0.0/0"
-    route.~1259162026.gateway_id:                "<computed>"
-    route.~1259162026.instance_id:               ""
-    route.~1259162026.nat_gateway_id:            ""
-    route.~1259162026.network_interface_id:      ""
-    route.~1259162026.vpc_peering_connection_id: ""
-    tags.%:                                      "3"
-    tags.Author:                                 "ReactiveOps"
-    tags.Managed By:                             "Terraform"
-    tags.Name:                                   "public"
-    vpc_id:                                      "<computed>"
+[0m    route.#:         "<computed>"
+    tags.%:          "3"
+    tags.Author:     "ReactiveOps"
+    tags.Managed By: "Terraform"
+    tags.Name:       "public"
+    vpc_id:          "<computed>"
 [0m
 [0m[32m+ aws_route_table_association.private_admin.0
 [0m    route_table_id: "<computed>"
@@ -329,4 +335,4 @@ Note: You didn't specify an "-out" parameter to save this plan, so when
     tags.Name:                 "vpc-module-test"
 [0m
 [0m
-[0m[1mPlan:[0m 39 to add, 0 to change, 0 to destroy.[0m
+[0m[1mPlan:[0m 40 to add, 0 to change, 0 to destroy.[0m


### PR DESCRIPTION
As mentioned in https://www.terraform.io/docs/providers/aws/r/route.html:

```
NOTE on Route Tables and Routes: Terraform currently provides both a standalone Route resource and a Route Table resource with routes defined in-line. At this time you cannot use a Route Table with in-line routes in conjunction with any Route resources. Doing so will cause a conflict of rule settings and will overwrite rules.
```

Even if the table id was outputted it would not be useable with the 
`route` resource. Each run would cause a “flapping” of the resource. One
run would add the route, the next would remove the route. 

Moving the route out of the table resource will prevent this conflict and
allow routes to be added in other modules.