### PR TITLE
0.12 migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 TEMPDIR := $(shell mktemp -d)
 
-TF_VERSION = 0.11.8
+TF_VERSION = 0.12.9
 TF_PLATFORM = darwin
 SHELL := /bin/bash
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ This module has been tested with Terraform version 0.11.8
 
 ```
 module "vpc" {
-  source = "git::ssh://git@github.com/reactiveops/terraform-vpc.git?ref=2.0.2"
+  source = "git::ssh://git@github.com/reactiveops/terraform-vpc.git?ref=3.0.0"
 
-  aws_region = "${var.aws_region}"
+  aws_region = var.aws_region
 
-  az_count =  "${var.az_count}"
-  aws_azs = "${var.aws_azs}"
+  az_count =  var.az_count
+  aws_azs = var.aws_azs
 
-  vpc_cidr_base = "${var.vpc_cidr_base}"
+  vpc_cidr_base = var.vpc_cidr_base
 
 }
 ```

--- a/eip.tf
+++ b/eip.tf
@@ -13,11 +13,12 @@
 #limitations under the License.
 
 resource "aws_eip" "mod_nat" {
-  count = "${((var.multi_az_nat_gateway * var.az_count) + (var.single_nat_gateway * 1))}"
-  tags = "${var.global_tags}"
-  vpc = true
+  count = var.multi_az_nat_gateway * var.az_count + var.single_nat_gateway * 1
+  tags  = var.global_tags
+  vpc   = true
 }
 
 output "aws_eip_nat_ips" {
-  value = ["${aws_eip.mod_nat.*.public_ip}"]
+  value = [aws_eip.mod_nat.*.public_ip]
 }
+

--- a/internet-gateway.tf
+++ b/internet-gateway.tf
@@ -13,9 +13,13 @@
 #limitations under the License.
 
 resource "aws_internet_gateway" "default" {
-  vpc_id = "${aws_vpc.default.id}"
-  tags = "${merge(var.global_tags,
-                  map("Name", "${var.aws_vpc_name}"),
-                  var.internet_gateway_tags)}"
-
+  vpc_id = aws_vpc.default.id
+  tags = merge(
+    var.global_tags,
+    {
+      "Name" = var.aws_vpc_name
+    },
+    var.internet_gateway_tags,
+  )
 }
+

--- a/nat-gateway.tf
+++ b/nat-gateway.tf
@@ -13,20 +13,25 @@
 #limitations under the License.
 
 resource "aws_nat_gateway" "nat_gateway" {
-  count = "${((var.multi_az_nat_gateway * var.az_count) + (var.single_nat_gateway * 1))}"
-  subnet_id = "${element(aws_subnet.public.*.id, count.index)}"
-  allocation_id = "${element(aws_eip.mod_nat.*.id, count.index)}"
-  tags = "${var.global_tags}"
-  depends_on = ["aws_internet_gateway.default","aws_eip.mod_nat","aws_subnet.public"]
-  lifecycle = {
-                ignore_changes = ["tags"]
-              }
+  count         = var.multi_az_nat_gateway * var.az_count + var.single_nat_gateway * 1
+  subnet_id     = element(aws_subnet.public.*.id, count.index)
+  allocation_id = element(aws_eip.mod_nat.*.id, count.index)
+  tags          = var.global_tags
+  depends_on = [
+    aws_internet_gateway.default,
+    aws_eip.mod_nat,
+    aws_subnet.public,
+  ]
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 output "aws_nat_gateway_count" {
-  value = "${length(aws_nat_gateway.nat_gateway.*.id)}"
+  value = length(aws_nat_gateway.nat_gateway.*.id)
 }
 
 output "aws_nat_gateway_ids" {
-  value = ["${aws_nat_gateway.nat_gateway.*.id}"]
+  value = [aws_nat_gateway.nat_gateway.*.id]
 }
+

--- a/route-table.tf
+++ b/route-table.tf
@@ -12,43 +12,53 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-
 # Routing table for public subnets
 resource "aws_route_table" "public" {
-  vpc_id = "${aws_vpc.default.id}"
-  tags = "${merge(var.global_tags,
-                  map("Name", "public"),
-                  var.public_route_table_tags)}"
+  vpc_id = aws_vpc.default.id
+  tags = merge(
+    var.global_tags,
+    {
+      "Name" = "public"
+    },
+    var.public_route_table_tags,
+  )
 }
 
 output "aws_route_table_public_ids" {
-  value = ["${aws_route_table.public.id}"]
+  value = [aws_route_table.public.id]
 }
 
 resource "aws_route" "public_internet_gateway" {
-  route_table_id = "${aws_route_table.public.id}"
+  route_table_id         = aws_route_table.public.id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id = "${aws_internet_gateway.default.id}"
+  gateway_id             = aws_internet_gateway.default.id
 }
-
 
 # Routing table for private subnets
 resource "aws_route_table" "private" {
-  count = "${((var.multi_az_nat_gateway * var.az_count) + (var.single_nat_gateway * 1))}"
-  vpc_id = "${aws_vpc.default.id}"
-  tags = "${merge(var.global_tags,
-                  map("Name", "private_az${(count.index +1)}"),
-                  var.private_route_table_tags)}"
+  count  = var.multi_az_nat_gateway * var.az_count + var.single_nat_gateway * 1
+  vpc_id = aws_vpc.default.id
+  tags = merge(
+    var.global_tags,
+    {
+      "Name" = "private_az${count.index + 1}"
+    },
+    var.private_route_table_tags,
+  )
 }
 
 output "aws_route_table_private_ids" {
-  value = ["${aws_route_table.private.*.id}"]
+  value = [aws_route_table.private.*.id]
 }
 
 resource "aws_route" "private_nat_gateway" {
-  count = "${((var.multi_az_nat_gateway * var.az_count) + (var.single_nat_gateway * 1))}"
-  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
-  nat_gateway_id = "${element(aws_nat_gateway.nat_gateway.*.id, count.index)}"
+  count                  = var.multi_az_nat_gateway * var.az_count + var.single_nat_gateway * 1
+  route_table_id         = element(aws_route_table.private.*.id, count.index)
+  nat_gateway_id         = element(aws_nat_gateway.nat_gateway.*.id, count.index)
   destination_cidr_block = "0.0.0.0/0"
-  depends_on = ["aws_route_table.private","aws_nat_gateway.nat_gateway"]
+  depends_on = [
+    aws_route_table.private,
+    aws_nat_gateway.nat_gateway,
+  ]
 }
+

--- a/subnets.tf
+++ b/subnets.tf
@@ -17,81 +17,98 @@
 #
 
 resource "aws_subnet" "admin" {
-  count = "${var.az_count}"
-  vpc_id = "${aws_vpc.default.id}"
-  cidr_block = "${var.vpc_cidr_base}${lookup(var.admin_subnet_cidrs, format("zone%d", count.index))}"
-  availability_zone = "${element(split(", ", var.aws_azs), count.index)}"
-  tags = "${merge(var.global_tags,
-                  map("Name", "admin_az${(count.index +1)}"),
-                  var.admin_subnet_tags)}"
+  count             = var.az_count
+  vpc_id            = aws_vpc.default.id
+  cidr_block        = "${var.vpc_cidr_base}${var.admin_subnet_cidrs[format("zone%d", count.index)]}"
+  availability_zone = element(split(", ", var.aws_azs), count.index)
+  tags = merge(
+    var.global_tags,
+    {
+      "Name" = "admin_az${count.index + 1}"
+    },
+    var.admin_subnet_tags,
+  )
 }
 
 output "aws_subnet_admin_ids" {
-  value = ["${aws_subnet.admin.*.id}"]
+  value = [aws_subnet.admin.*.id]
 }
 
 resource "aws_route_table_association" "private_admin" {
-  count = "${var.az_count}"
-  subnet_id = "${element(aws_subnet.admin.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
+  count          = var.az_count
+  subnet_id      = element(aws_subnet.admin.*.id, count.index)
+  route_table_id = element(aws_route_table.private.*.id, count.index)
 }
 
 resource "aws_subnet" "public" {
-  count = "${var.az_count}"
-  vpc_id = "${aws_vpc.default.id}"
-  cidr_block = "${var.vpc_cidr_base}${lookup(var.public_subnet_cidrs, format("zone%d", count.index))}"
-  availability_zone = "${element(split(", ", var.aws_azs), count.index)}"
-  tags = "${merge(var.global_tags,
-                  map("Name", "public_az${(count.index +1)}"),
-                  var.public_subnet_tags)}"
+  count             = var.az_count
+  vpc_id            = aws_vpc.default.id
+  cidr_block        = "${var.vpc_cidr_base}${var.public_subnet_cidrs[format("zone%d", count.index)]}"
+  availability_zone = element(split(", ", var.aws_azs), count.index)
+  tags = merge(
+    var.global_tags,
+    {
+      "Name" = "public_az${count.index + 1}"
+    },
+    var.public_subnet_tags,
+  )
 }
 
 output "aws_subnet_public_ids" {
-  value = ["${aws_subnet.public.*.id}"]
+  value = [aws_subnet.public.*.id]
 }
 
 resource "aws_route_table_association" "public_public" {
-  count = "${var.az_count}"
-  subnet_id = "${element(aws_subnet.public.*.id, count.index)}"
-  route_table_id = "${aws_route_table.public.id}"
+  count          = var.az_count
+  subnet_id      = element(aws_subnet.public.*.id, count.index)
+  route_table_id = aws_route_table.public.id
 }
 
 resource "aws_subnet" "private_prod" {
-  count = "${var.az_count}"
-  vpc_id = "${aws_vpc.default.id}"
-  cidr_block = "${var.vpc_cidr_base}${lookup(var.private_prod_subnet_cidrs, format("zone%d", count.index))}"
-  availability_zone = "${element(split(", ", var.aws_azs), count.index)}"
-  tags = "${merge(var.global_tags,
-                  map("Name", "private_prod_az${(count.index +1)}"),
-                  var.private_prod_subnet_tags)}"
+  count             = var.az_count
+  vpc_id            = aws_vpc.default.id
+  cidr_block        = "${var.vpc_cidr_base}${var.private_prod_subnet_cidrs[format("zone%d", count.index)]}"
+  availability_zone = element(split(", ", var.aws_azs), count.index)
+  tags = merge(
+    var.global_tags,
+    {
+      "Name" = "private_prod_az${count.index + 1}"
+    },
+    var.private_prod_subnet_tags,
+  )
 }
 
 output "aws_subnet_private_prod_ids" {
-  value = ["${aws_subnet.private_prod.*.id}"]
+  value = [aws_subnet.private_prod.*.id]
 }
 
 resource "aws_route_table_association" "private_private_prod" {
-  count = "${var.az_count}"
-  subnet_id = "${element(aws_subnet.private_prod.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
+  count          = var.az_count
+  subnet_id      = element(aws_subnet.private_prod.*.id, count.index)
+  route_table_id = element(aws_route_table.private.*.id, count.index)
 }
 
 resource "aws_subnet" "private_working" {
-  count = "${var.az_count}"
-  vpc_id = "${aws_vpc.default.id}"
-  cidr_block = "${var.vpc_cidr_base}${lookup(var.private_working_subnet_cidrs, format("zone%d", count.index))}"
-  availability_zone = "${element(split(", ", var.aws_azs), count.index)}"
-  tags = "${merge(var.global_tags,
-                  map("Name", "private_working_az${(count.index +1)}"),
-                  var.private_working_subnet_tags)}"
+  count             = var.az_count
+  vpc_id            = aws_vpc.default.id
+  cidr_block        = "${var.vpc_cidr_base}${var.private_working_subnet_cidrs[format("zone%d", count.index)]}"
+  availability_zone = element(split(", ", var.aws_azs), count.index)
+  tags = merge(
+    var.global_tags,
+    {
+      "Name" = "private_working_az${count.index + 1}"
+    },
+    var.private_working_subnet_tags,
+  )
 }
 
 output "aws_subnet_private_working_ids" {
-  value = ["${aws_subnet.private_working.*.id}"]
+  value = [aws_subnet.private_working.*.id]
 }
 
 resource "aws_route_table_association" "private_private_working" {
-  count = "${var.az_count}"
-  subnet_id = "${element(aws_subnet.private_working.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
+  count          = var.az_count
+  subnet_id      = element(aws_subnet.private_working.*.id, count.index)
+  route_table_id = element(aws_route_table.private.*.id, count.index)
 }
+

--- a/tests/provider.tf
+++ b/tests/provider.tf
@@ -2,7 +2,7 @@ variable "aws_access_key" {}
 variable "aws_secret_key" {}
 
 provider "aws" {
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
-  region     = "${var.aws_region}"
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+  region     = var.aws_region
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,8 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-variable "aws_region" {}
+variable "aws_region" {
+}
 
 variable "aws_vpc_name" {
   default = "vpc"
@@ -20,13 +21,12 @@ variable "aws_vpc_name" {
 
 variable "aws_azs" {
   description = "comma separated string of availability zones in order of precedence"
-  default = "us-east-1a, us-east-1d, us-east-1e, us-east-1c"
-
+  default     = "us-east-1a, us-east-1d, us-east-1e, us-east-1c"
 }
 
 variable "az_count" {
   description = "number of active availability zones in VPC"
-  default = "3"
+  default     = "3"
 }
 
 variable "vpc_cidr_base" {
@@ -51,7 +51,7 @@ variable "vpc_enable_classiclink" {
 
 variable "admin_subnet_parent_cidr" {
   description = "parent CIDR for the administrative subnets"
-  default = ".0.0/19"
+  default     = ".0.0/19"
 }
 
 variable "admin_subnet_cidrs" {
@@ -66,12 +66,12 @@ variable "admin_subnet_cidrs" {
 
 variable "admin_subnet_tags" {
   description = "Tags to apply to the admin subnet"
-  default = {}
+  default     = {}
 }
 
 variable "public_subnet_parent_cidr" {
   description = "parent CIDR for the public subnets"
-  default = ".32.0/19"
+  default     = ".32.0/19"
 }
 
 variable "public_subnet_cidrs" {
@@ -86,12 +86,12 @@ variable "public_subnet_cidrs" {
 
 variable "public_subnet_tags" {
   description = "Tags to apply to the public subnets"
-  default = {}
+  default     = {}
 }
 
 variable "private_prod_subnet_parent_cidr" {
   description = "parent CIDR for the private production subnets"
-  default = ".64.0/19"
+  default     = ".64.0/19"
 }
 
 variable "private_prod_subnet_cidrs" {
@@ -106,12 +106,12 @@ variable "private_prod_subnet_cidrs" {
 
 variable "private_prod_subnet_tags" {
   description = "Tags to apply to the private production subnets"
-  default = {}
+  default     = {}
 }
 
 variable "private_working_subnet_parent_cidr" {
   description = "parent CIDR for the private working subnets"
-  default = ".96.0/19"
+  default     = ".96.0/19"
 }
 
 variable "private_working_subnet_cidrs" {
@@ -126,27 +126,27 @@ variable "private_working_subnet_cidrs" {
 
 variable "private_working_subnet_tags" {
   description = "Tags to apply to the private working subnets"
-  default = {}
+  default     = {}
 }
 
 variable "multi_az_nat_gateway" {
   description = "place a NAT gateway in each AZ"
-  default = 1
+  default     = 1
 }
 
 variable "single_nat_gateway" {
   description = "use a single NAT gateway to serve outbound traffic for all AZs"
-  default = 0
+  default     = 0
 }
 
 variable "enable_s3_vpc_endpoint" {
   description = "Create a VPC S3 gateway endpoint and private subnet route entries. This will route S3 traffic over private network rather than over NAT gateways."
-  default = "false"
+  default     = "false"
 }
 
 variable "s3_vpc_endpoint_policy" {
   description = "S3 VPC endpoint gateway policy document. Bucket and IAM policies still apply."
-  default = <<POLICY
+  default     = <<POLICY
 {
     "Statement": [
         {   
@@ -160,11 +160,12 @@ variable "s3_vpc_endpoint_policy" {
     "Version": "2008-10-17"
 }
 POLICY
+
 }
 
 variable "s3_vpc_endpoint_route_table_ids" {
   description = "By default routes to the s3 endpoint are added for private subnet route tables. Pass additional route table ids that require routes."
-  type = "list"
+  type = list(string)
   default = []
 }
 
@@ -185,9 +186,10 @@ variable "private_route_table_tags" {
 
 variable "global_tags" {
   description = "AWS tags that will be added to all resources managed herein"
-  type = "map"
+  type = map(string)
   default = {
     "Author" = "ReactiveOps"
     "Managed By" = "Terraform"
   }
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,7 @@
 
 terraform {
   required_version = ">= 0.12"
+  required_providers {
+    aws = ">=2.30.0"
+  }
 }

--- a/vpc-endpoint.tf
+++ b/vpc-endpoint.tf
@@ -13,9 +13,13 @@
 #limitations under the License.
 
 resource "aws_vpc_endpoint" "s3_endpoint" {
-  count = "${var.enable_s3_vpc_endpoint ? 1 : 0}"
-  vpc_id = "${aws_vpc.default.id}"
+  count        = var.enable_s3_vpc_endpoint ? 1 : 0
+  vpc_id       = aws_vpc.default.id
   service_name = "com.amazonaws.${var.aws_region}.s3"
-  route_table_ids = ["${concat(aws_route_table.private.*.id, var.s3_vpc_endpoint_route_table_ids)}"]
-  policy = "${var.s3_vpc_endpoint_policy}"
+  route_table_ids = concat(
+    aws_route_table.private.*.id,
+    var.s3_vpc_endpoint_route_table_ids,
+  )
+  policy = var.s3_vpc_endpoint_policy
 }
+

--- a/vpc.tf
+++ b/vpc.tf
@@ -13,21 +13,27 @@
 #limitations under the License.
 
 resource "aws_vpc" "default" {
-  cidr_block = "${var.vpc_cidr_base}.0.0/16"
-  instance_tenancy = "${var.vpc_instance_tenancy}"
-  enable_dns_support = "${var.vpc_enable_dns_support}"
-  enable_dns_hostnames = "${var.vpc_enable_dns_hostnames}"
-  enable_classiclink = "${var.vpc_enable_classiclink}"
-  tags = "${merge(var.global_tags, map("Name", "${var.aws_vpc_name}"))}"
-  lifecycle = { 
-                ignore_changes = ["tags"]
-              }
+  cidr_block           = "${var.vpc_cidr_base}.0.0/16"
+  instance_tenancy     = var.vpc_instance_tenancy
+  enable_dns_support   = var.vpc_enable_dns_support
+  enable_dns_hostnames = var.vpc_enable_dns_hostnames
+  enable_classiclink   = var.vpc_enable_classiclink
+  tags = merge(
+    var.global_tags,
+    {
+      "Name" = var.aws_vpc_name
+    },
+  )
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 output "aws_vpc_id" {
-  value = "${aws_vpc.default.id}"
+  value = aws_vpc.default.id
 }
 
 output "aws_vpc_cidr" {
-  value = "${aws_vpc.default.cidr_block}"
+  value = aws_vpc.default.cidr_block
 }
+


### PR DESCRIPTION
This PR upgrades the root module to support Terraform 0.12. The `single-cluster` modules remain untouched. This was tested a few different ways on existing 0.11 VPCs. All existing inputs and outputs are untouched. These changes should be compatible with existing infrastructure created using 0.11.