### PR TITLE
remove brackets from output values

### DIFF
--- a/eip.tf
+++ b/eip.tf
@@ -19,6 +19,6 @@ resource "aws_eip" "mod_nat" {
 }
 
 output "aws_eip_nat_ips" {
-  value = [aws_eip.mod_nat.*.public_ip]
+  value = aws_eip.mod_nat.*.public_ip
 }
 

--- a/nat-gateway.tf
+++ b/nat-gateway.tf
@@ -32,6 +32,6 @@ output "aws_nat_gateway_count" {
 }
 
 output "aws_nat_gateway_ids" {
-  value = [aws_nat_gateway.nat_gateway.*.id]
+  value = aws_nat_gateway.nat_gateway.*.id
 }
 

--- a/route-table.tf
+++ b/route-table.tf
@@ -25,7 +25,7 @@ resource "aws_route_table" "public" {
 }
 
 output "aws_route_table_public_ids" {
-  value = [aws_route_table.public.id]
+  value = aws_route_table.public.id
 }
 
 resource "aws_route" "public_internet_gateway" {
@@ -48,7 +48,7 @@ resource "aws_route_table" "private" {
 }
 
 output "aws_route_table_private_ids" {
-  value = [aws_route_table.private.*.id]
+  value = aws_route_table.private.*.id
 }
 
 resource "aws_route" "private_nat_gateway" {

--- a/subnets.tf
+++ b/subnets.tf
@@ -31,7 +31,7 @@ resource "aws_subnet" "admin" {
 }
 
 output "aws_subnet_admin_ids" {
-  value = [aws_subnet.admin.*.id]
+  value = aws_subnet.admin.*.id
 }
 
 resource "aws_route_table_association" "private_admin" {
@@ -55,7 +55,7 @@ resource "aws_subnet" "public" {
 }
 
 output "aws_subnet_public_ids" {
-  value = [aws_subnet.public.*.id]
+  value = aws_subnet.public.*.id
 }
 
 resource "aws_route_table_association" "public_public" {
@@ -79,7 +79,7 @@ resource "aws_subnet" "private_prod" {
 }
 
 output "aws_subnet_private_prod_ids" {
-  value = [aws_subnet.private_prod.*.id]
+  value = aws_subnet.private_prod.*.id
 }
 
 resource "aws_route_table_association" "private_private_prod" {
@@ -103,7 +103,7 @@ resource "aws_subnet" "private_working" {
 }
 
 output "aws_subnet_private_working_ids" {
-  value = [aws_subnet.private_working.*.id]
+  value = aws_subnet.private_working.*.id
 }
 
 resource "aws_route_table_association" "private_private_working" {


### PR DESCRIPTION
I've been seeing issues with these brackets on output values when using them elsewhere in terraform configuration on 0.12. Looking at the docs, we apparently should have done this in 0.11, but now we're forced to on 0.12: https://www.terraform.io/upgrade-guides/0-12.html#referring-to-list-variables

The brackets around list variables are no longer needed. 