### PR TITLE
Locals vars should not be lists of lists, but just vars.

### DIFF
--- a/modules/single-cluster/dynamics.tf
+++ b/modules/single-cluster/dynamics.tf
@@ -1,7 +1,7 @@
 # Dynamics house all the CIDR and other dynamic elements of this module
 
 locals {
-  public_cidr_subnets  = [var.public_subnets_list]
-  private_cidr_subnets = [var.private_subnets_list]
-  admin_cidr_subnets   = [var.admin_subnets_list]
+  public_cidr_subnets  = var.public_subnets_list
+  private_cidr_subnets = var.private_subnets_list
+  admin_cidr_subnets   = var.admin_subnets_list
 }


### PR DESCRIPTION
The local vars `subnets_list` variables are
defined as `type = list(string)`, but then later on, the `cidr_subnets`
variables are defined as a list _of_ that list, for example:

In `variables.tf`:

```
variable "public_subnets_list" {
  type        = list(string)
  description = "A list of the subnets to create for public subnets"
}
```

In `dynamics.tf`:

```
locals {
  public_cidr_subnets  = [var.public_subnets_list]
...
```

This will always fail, because a value cannot be set appropriately on
the module when it's called, or else you can set it, but the module
won't compile. :slightly_frowning_face: