### PR TITLE
remove classiclink params from module and examples

### DIFF
--- a/modules/single-cluster/variables.tf
+++ b/modules/single-cluster/variables.tf
@@ -47,10 +47,6 @@ variable "vpc_enable_dns_hostnames" {
   default = "true"
 }
 
-variable "vpc_enable_classiclink" {
-  default = "false"
-}
-
 ## Tagging Settings
 variable "extra_tags_global" {
   type        = map(string)

--- a/modules/single-cluster/vpc.tf
+++ b/modules/single-cluster/vpc.tf
@@ -4,7 +4,6 @@ resource "aws_vpc" "kube_vpc" {
   instance_tenancy     = var.vpc_instance_tenancy
   enable_dns_support   = var.vpc_enable_dns_support
   enable_dns_hostnames = var.vpc_enable_dns_hostnames
-  enable_classiclink   = var.vpc_enable_classiclink
   tags = merge(
     local.tags,
     {

--- a/tests/fixtures/terraform.1az.tfvars.example.output
+++ b/tests/fixtures/terraform.1az.tfvars.example.output
@@ -195,8 +195,6 @@ Terraform will perform the following actions:
       default_route_table_id:           <computed>
       default_security_group_id:        <computed>
       dhcp_options_id:                  <computed>
-      enable_classiclink:               "false"
-      enable_classiclink_dns_support:   <computed>
       enable_dns_hostnames:             "true"
       enable_dns_support:               "true"
       instance_tenancy:                 "default"

--- a/tests/fixtures/terraform.nat-gw.tfvars.example.output
+++ b/tests/fixtures/terraform.nat-gw.tfvars.example.output
@@ -477,8 +477,6 @@ Terraform will perform the following actions:
       default_route_table_id:           <computed>
       default_security_group_id:        <computed>
       dhcp_options_id:                  <computed>
-      enable_classiclink:               "false"
-      enable_classiclink_dns_support:   <computed>
       enable_dns_hostnames:             "true"
       enable_dns_support:               "true"
       instance_tenancy:                 "default"

--- a/tests/fixtures/terraform.s3ep.tfvars.example.output
+++ b/tests/fixtures/terraform.s3ep.tfvars.example.output
@@ -477,8 +477,6 @@ Terraform will perform the following actions:
       default_route_table_id:           <computed>
       default_security_group_id:        <computed>
       dhcp_options_id:                  <computed>
-      enable_classiclink:               "false"
-      enable_classiclink_dns_support:   <computed>
       enable_dns_hostnames:             "true"
       enable_dns_support:               "true"
       instance_tenancy:                 "default"

--- a/variables.tf
+++ b/variables.tf
@@ -45,10 +45,6 @@ variable "vpc_enable_dns_hostnames" {
   default = "true"
 }
 
-variable "vpc_enable_classiclink" {
-  default = "false"
-}
-
 variable "admin_subnet_parent_cidr" {
   description = "parent CIDR for the administrative subnets"
   default     = ".0.0/19"
@@ -149,7 +145,7 @@ variable "s3_vpc_endpoint_policy" {
   default     = <<POLICY
 {
     "Statement": [
-        {   
+        {
             "Sid": "FullAccess",
             "Action": "*",
             "Effect": "Allow",

--- a/vpc.tf
+++ b/vpc.tf
@@ -17,7 +17,6 @@ resource "aws_vpc" "default" {
   instance_tenancy     = var.vpc_instance_tenancy
   enable_dns_support   = var.vpc_enable_dns_support
   enable_dns_hostnames = var.vpc_enable_dns_hostnames
-  enable_classiclink   = var.vpc_enable_classiclink
   tags = merge(
     var.global_tags,
     {


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
AWS terraform provider version `5.0.0` removed support for the [enable_classiclink](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/vpc#enable_classiclink) and [enable_classiclink_dns_support](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/vpc#enable_classiclink_dns_support) parameters, which causes this terraform to fail with error message 
```
Error: Unsupported argument

  on .terraform/modules/vpc/main.tf line 33, in resource "aws_vpc" "this":
  33:   enable_classiclink_dns_support   = var.enable_classiclink_dns_support

An argument named "enable_classiclink_dns_support" is not expected here.
```

### What changes did you make?
Removed `enable_classiclink` and `enabled_classiclink_dns` from variables file, vpc.tf, and the examples. 

### What alternative solution should we consider, if any?
Could pin this on an earlier version of the provider but since ec2-classic is no longer supported I think it's time for a brave new world. 
